### PR TITLE
Timestamping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ build:
 	$(UNIBUILD)
 
 
+release:
+	RELEASE=1 $(MAKE)
+
+
 
 $(REPO): build
 	(((( \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ ifdef STOP
 UNIBUILD_OPTS += --stop $(STOP)
 endif
 
+ifdef RELEASE
+UNIBUILD_OPTS += --release 
+endif
 
 BUILD_LOG=unibuild-log
 TO_CLEAN += $(BUILD_LOG)

--- a/unibuild-package/unibuild-package/unibuild-deb.make
+++ b/unibuild-package/unibuild-package/unibuild-deb.make
@@ -47,8 +47,8 @@ ifeq "$(VERSION)" ""
 $(error Unable to find version in $(CHANGELOG).)
 endif
 
-ifdef TIMESTAMP
-    VERSION := $(VERSION)~$(TIMESTAMP)
+ifdef UNIBUILD_TIMESTAMP
+    VERSION := $(VERSION)~$(UNIBUILD_TIMESTAMP)
     ifeq "$(SRCFORMAT)" "native"
         DEBVERSION := $(VERSION)
     else
@@ -179,7 +179,7 @@ BUILD_DEPS_PACKAGE := $(SOURCE)-build-deps
 # tarball for all build methods (tarball/source directory/none)
 
 build:: $(TO_BUILD) $(PRODUCTS_DIR)
-ifdef TIMESTAMP
+ifdef UNIBUILD_TIMESTAMP
 	@printf "\nUpdate changelog for SNAPSHOT build\n\n"
 	( cd $(BUILD_UNPACK_DIR) \
         && dch -c debian/changelog -Mb --distribution=UNRELEASED --newversion=$(DEBVERSION) \

--- a/unibuild-package/unibuild-package/unibuild-deb.make
+++ b/unibuild-package/unibuild-package/unibuild-deb.make
@@ -37,10 +37,10 @@ SRCFORMAT := $(shell grep -Eo '([a-z]+)' '$(DEBIAN_DIR)/source/format')
 
 CHANGELOG := $(DEBIAN_DIR)/changelog
 VERSION := $(shell dpkg-parsechangelog -l '$(CHANGELOG)' \
-    | sed -n 's|Version: \([^-]*\)\(-[0-9.]*\)*$$|\1|p' \
+    | sed -n 's|Version: \([^-]*\)\(-.*\)*$$|\1|p' \
     )
 REVISION := $(shell dpkg-parsechangelog -l '$(CHANGELOG)' \
-    | sed -n 's|Version: \([^-]*\)\(-[0-9.]*\)*$$|\2|p' \
+    | sed -n 's|Version: \([^-]*\)\(-.*\)*$$|\2|p' \
     )
 
 ifeq "$(VERSION)" ""

--- a/unibuild-package/unibuild-package/unibuild-deb.make
+++ b/unibuild-package/unibuild-package/unibuild-deb.make
@@ -36,8 +36,13 @@ endif
 SRCFORMAT := $(shell grep -Eo '([a-z]+)' '$(DEBIAN_DIR)/source/format')
 
 CHANGELOG := $(DEBIAN_DIR)/changelog
+# Break down VERSION and REVISION
 VERSION := $(shell dpkg-parsechangelog -l '$(CHANGELOG)' \
     | sed -n 's|Version: \([^-]*\)\(-.*\)*$$|\1|p' \
+    )
+# And leaving out any +dfsg.x suffix when looking for TARBALL
+NODFSG_VERSION := $(shell dpkg-parsechangelog -l '$(CHANGELOG)' \
+        | sed -n 's|Version: \([^-+]*\)\(+dfsg[.0-9]*\)\?\(-.*\)*$$|\1|p' \
     )
 REVISION := $(shell dpkg-parsechangelog -l '$(CHANGELOG)' \
     | sed -n 's|Version: \([^-]*\)\(-.*\)*$$|\2|p' \
@@ -48,7 +53,6 @@ $(error Unable to find version in $(CHANGELOG).)
 endif
 
 # If we have a UNIBUILD_TIMESTAMP, we are building a snapshot release
-NOSNAP_VERSION := $(VERSION)
 ifdef UNIBUILD_TIMESTAMP
 VERSION := $(VERSION)~$(UNIBUILD_TIMESTAMP)
 ifeq "$(SRCFORMAT)" "native"
@@ -66,7 +70,7 @@ endif
 
 TARBALL_SUFFIX := .tar.gz
 
-SOURCE_TARBALLS := $(wildcard $(SOURCE)-$(NOSNAP_VERSION)$(TARBALL_SUFFIX) $(SOURCE)$(TARBALL_SUFFIX))
+SOURCE_TARBALLS := $(wildcard $(SOURCE)-$(NODFSG_VERSION)$(TARBALL_SUFFIX) $(SOURCE)$(TARBALL_SUFFIX))
 ifeq ($(words $(SOURCE_TARBALLS)),0)
 SOURCE_TARBALL :=
 else ifeq  ($(words $(SOURCE_TARBALLS)),1)

--- a/unibuild-package/unibuild-package/unibuild-packaging/deb/changelog
+++ b/unibuild-package/unibuild-package/unibuild-packaging/deb/changelog
@@ -1,4 +1,4 @@
-unibuild-package (1.0-1) perfsonar-4.4; urgency=low
+unibuild-package (1.0-1) perfsonar-5.0; urgency=low
 
   * First version
 

--- a/unibuild/unibuild/libexec/commands/build
+++ b/unibuild/unibuild/libexec/commands/build
@@ -23,14 +23,14 @@ START=
 START_PACKAGE=
 STOP=
 STOP_PACKAGE=
-export TIMESTAMP=$(date +%Y%m%d%H%M%S)
+export UNIBUILD_TIMESTAMP=$(date +%Y%m%d%H%M%S)
 
 while [ "$1" ]
 do
     case "$1" in
 
 	--release)
-	    unset TIMESTAMP
+	    unset UNIBUILD_TIMESTAMP
 	    shift
 	    ;;
 

--- a/unibuild/unibuild/libexec/commands/build
+++ b/unibuild/unibuild/libexec/commands/build
@@ -23,7 +23,6 @@ START=
 START_PACKAGE=
 STOP=
 STOP_PACKAGE=
-export UNIBUILD_TIMESTAMP=$(date +%Y%m%d%H%M%S)
 
 while [ "$1" ]
 do

--- a/unibuild/unibuild/libexec/commands/build
+++ b/unibuild/unibuild/libexec/commands/build
@@ -14,6 +14,7 @@ OPTIONS:
 
   --start P  Start with package P
   --stop P   Stop after package P
+  --release  Do a release build, without timestamp
 
 EOF
 }
@@ -22,10 +23,16 @@ START=
 START_PACKAGE=
 STOP=
 STOP_PACKAGE=
+export TIMESTAMP=$(date +%Y%m%d%H%M%S)
 
 while [ "$1" ]
 do
     case "$1" in
+
+	--release)
+	    unset TIMESTAMP
+	    shift
+	    ;;
 
 	--start)
 	    START=$2

--- a/unibuild/unibuild/libexec/unibuild
+++ b/unibuild/unibuild/libexec/unibuild
@@ -11,6 +11,10 @@ export UNIBUILD=$(dirname "${UNIBUILD_CANONICAL}")
 
 . "${UNIBUILD}/common"
 
+# Set the timestamp only if something else hasn't set it first.
+[ -z "${UNIBUILD_TIMESTAMP}" ] \
+    && export UNIBUILD_TIMESTAMP=$(date +%Y%m%d%H%M%S)
+
 
 help()
 {

--- a/unibuild/unibuild/unibuild-packaging/deb/changelog
+++ b/unibuild/unibuild/unibuild-packaging/deb/changelog
@@ -1,4 +1,4 @@
-unibuild (1.0-1) perfsonar-4.4; urgency=low
+unibuild (1.0-1) perfsonar-5.0; urgency=low
 
   * First version
 


### PR DESCRIPTION
This PR will change the default behaviour of `unibuild` to make it create snapshot/nightly packages with a date and time suffix to the version number. In case of a release build, `unibuild` then needs to be called with the `--release` option.