### PR TITLE
Docker envs

### DIFF
--- a/docker-envs/Dockerfile-alma8
+++ b/docker-envs/Dockerfile-alma8
@@ -1,8 +1,11 @@
 FROM almalinux:latest
 
 #Install pre-requisites
+#Install utils like tree useful for debugging
+#Enable powertools since contains common dependencies
 RUN dnf update -y && \
-    dnf install -y rpm-build m4 make redhat-lsb-core sudo 
+    dnf install -y rpm-build m4 make redhat-lsb-core sudo dnf-plugins-core epel-release tree && \
+    dnf config-manager --set-enabled powertools
 
 #Copy unibuild source
 COPY . /usr/share/unibuild/

--- a/docker-envs/Dockerfile-alma8
+++ b/docker-envs/Dockerfile-alma8
@@ -1,0 +1,17 @@
+FROM almalinux:latest
+
+#Install pre-requisites
+RUN dnf update -y && \
+    dnf install -y rpm-build m4 make redhat-lsb-core sudo 
+
+#Copy unibuild source
+COPY . /usr/share/unibuild/
+
+#Install unibuild
+WORKDIR /usr/share/unibuild
+RUN make
+
+
+#Shared volume for code to build
+VOLUME /app
+WORKDIR /app

--- a/docker-envs/Dockerfile-centos7
+++ b/docker-envs/Dockerfile-centos7
@@ -1,0 +1,19 @@
+FROM centos:7
+
+#Install pre-requisites
+#Install utils like tree useful for debugging
+#Enable powertools since contains common dependencies
+RUN yum update -y && \
+    yum install -y rpm-build m4 make redhat-lsb-core sudo epel-release tree
+
+#Copy unibuild source
+COPY . /usr/share/unibuild/
+
+#Install unibuild
+WORKDIR /usr/share/unibuild
+RUN make
+
+
+#Shared volume for code to build
+VOLUME /app
+WORKDIR /app

--- a/docker-envs/Dockerfile-debian10
+++ b/docker-envs/Dockerfile-debian10
@@ -1,0 +1,19 @@
+FROM debian:10
+
+#Install pre-requisites
+#Install utils like tree useful for debugging
+#Enable powertools since contains common dependencies
+RUN apt update -y && \
+    apt install -y sudo git make m4 pylint rsync dpkg-dev devscripts lsb-release tree screen wget man-db man htop emacs-nox
+
+#Copy unibuild source
+COPY . /usr/share/unibuild/
+
+#Install unibuild
+WORKDIR /usr/share/unibuild
+RUN make
+
+
+#Shared volume for code to build
+VOLUME /app
+WORKDIR /app

--- a/docker-envs/Dockerfile-debian10
+++ b/docker-envs/Dockerfile-debian10
@@ -4,7 +4,7 @@ FROM debian:10
 #Install utils like tree useful for debugging
 #Enable powertools since contains common dependencies
 RUN apt update -y && \
-    apt install -y sudo git make m4 pylint rsync dpkg-dev devscripts lsb-release tree screen wget man-db man htop emacs-nox
+    apt install -y sudo rsync pylint devscripts tree screen wget htop emacs-nox vim
 
 #Copy unibuild source
 COPY . /usr/share/unibuild/
@@ -12,7 +12,6 @@ COPY . /usr/share/unibuild/
 #Install unibuild
 WORKDIR /usr/share/unibuild
 RUN make
-
 
 #Shared volume for code to build
 VOLUME /app

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.8'
 services:
   alma8:
-    image: perfsonar/unibuild-alma8:latest
+    image: ghcr.io/perfsonar/unibuild/alma8:latest
     build:
       context: ../
       dockerfile: ./docker-envs/Dockerfile-alma8
     volumes:
       -  .:/app
   centos7:
-    image: perfsonar/unibuild-centos7:latest
+    image: ghcr.io/perfsonar/unibuild/centos7:latest
     build:
       context: ../
       dockerfile: ./docker-envs/Dockerfile-centos7
@@ -17,7 +17,7 @@ services:
     volumes:
       - .:/app
   debian10:
-    image: perfsonar/unibuild-debian10:latest
+    image: ghcr.io/perfsonar/unibuild/debian10:latest
     build:
       context: ../
       dockerfile: ./docker-envs/Dockerfile-debian10

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -6,4 +6,4 @@ services:
         context: ../
         dockerfile: ./docker-envs/Dockerfile-alma8
     volumes:
-      -  ../../:/app
+      -  .:/app

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -3,14 +3,23 @@ services:
   alma8:
     image: perfsonar/unibuild-alma8:latest
     build:
-        context: ../
-        dockerfile: ./docker-envs/Dockerfile-alma8
+      context: ../
+      dockerfile: ./docker-envs/Dockerfile-alma8
     volumes:
       -  .:/app
+  centos7:
+    image: perfsonar/unibuild-centos7:latest
+    build:
+      context: ../
+      dockerfile: ./docker-envs/Dockerfile-centos7
+      network: host
+    network_mode: "host"
+    volumes:
+      - .:/app
   debian10:
     image: perfsonar/unibuild-debian10:latest
     build:
-        context: ../
-        dockerfile: ./docker-envs/Dockerfile-debian10
+      context: ../
+      dockerfile: ./docker-envs/Dockerfile-debian10
     volumes:
       -  .:/app

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -7,3 +7,10 @@ services:
         dockerfile: ./docker-envs/Dockerfile-alma8
     volumes:
       -  .:/app
+  debian10:
+    image: perfsonar/unibuild-debian10:latest
+    build:
+        context: ../
+        dockerfile: ./docker-envs/Dockerfile-debian10
+    volumes:
+      -  .:/app

--- a/docker-envs/docker-compose.yml
+++ b/docker-envs/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  alma8:
+    image: perfsonar/unibuild-alma8:latest
+    build:
+        context: ../
+        dockerfile: ./docker-envs/Dockerfile-alma8
+    volumes:
+      -  ../../:/app

--- a/unibuild-package/unibuild-package/unibuild-rpm.make
+++ b/unibuild-package/unibuild-package/unibuild-rpm.make
@@ -36,7 +36,7 @@ ifneq "$(words $(SPEC))" "1"
   $(error $(RPM_DIR) contains more than one spec file)
 endif
 
-VERSION := $(shell rpm -q --queryformat="%{version}\n" --specfile '$(SPEC)')
+VERSION := $(shell rpm -q --queryformat="%{version}\n" --specfile '$(SPEC)' | head -n1)
 SOURCE_FILES := $(shell spectool -S $(SPEC) | awk '{ print $$2 }')
 PATCH_FILES := $(shell spectool -P $(SPEC) | awk '{ print $$2 }')
 

--- a/unibuild/unibuild/libexec/commands/make
+++ b/unibuild/unibuild/libexec/commands/make
@@ -27,9 +27,7 @@ EOF
 
 BUNDLE=
 DRY=
-[ -t 0 ] \
-    && FILE=unibuild-order \
-    || FILE=""
+FILE=unibuild-order
 REVERSE=cat
 START=
 STOP=


### PR DESCRIPTION
Adds docker environments for building packages. Biggest change to reviews is probably in unibuild/unibuild/libexec/commands/make. The TTY check was breaking the docker build. Eventually want to do some more work that does following:
- Build images in registry using github actions likely with some better tagging beyond just latest
- Remove build phase from docker-compose
- Add rocky8 and ubuntu20
- probably add "nightly-minor", "nightly-patch", "staging" and "prod" tags of images that have the corresponding rpm/deb repos pre-configured (mainly as a shortcut to doing builds when repo is bootstrapped and you don't care about a fresh environment). 